### PR TITLE
Only allow sdists to be uploaded by default

### DIFF
--- a/yolapi/pypi/upload.py
+++ b/yolapi/pypi/upload.py
@@ -93,6 +93,10 @@ def process(request):
     if '/' in files['content'].name:
         raise InvalidUpload("Invalid filename")
 
+    if post['filetype'] not in getattr(settings, 'PYPI_ALLOWED_UPLOAD_TYPES',
+                                       ('sdist',)):
+        raise InvalidUpload("File type disallowed by policy")
+
     metadata = parse_metadata(post)
 
     if md5sum(files['content']) != post['md5_digest']:

--- a/yolapi/settings.py
+++ b/yolapi/settings.py
@@ -205,6 +205,8 @@ PYPI_ALLOW_REPLACEMENT = True
 # Allow deleting packages
 PYPI_ALLOW_DELETION = True
 
+PYPI_ALLOWED_UPLOAD_TYPES = ('sdist',)
+
 # An available formatting that can be used for displaying date fields on
 # templates.
 SHORT_DATE_FORMAT = 'Y-m-d'


### PR DESCRIPTION
We'd like people to only upload `sdist`s. Eggs will be built internally by the celery worker.

There are times when one needs to build eggs by hand, and I guess `settings.py` would have to be edited on infra1 to accommodate those, when necessary :/ Alternatively we could have an upload user, distinct from the admin user, who can only upload sdists. But everyone is already using the admin user, so that wouldn't work....
