### PR TITLE
Reduce number of celery workers that yolapi has

### DIFF
--- a/deploy/templates/upstart/yolapi-worker.conf.template
+++ b/deploy/templates/upstart/yolapi-worker.conf.template
@@ -12,6 +12,7 @@ exec su -s /bin/sh -c 'exec "$0" "$@"' www-data -- \
                   --logfile {{aconf.path.celery_log}} \
                   --loglevel INFO \
                   --beat \
+                  --concurrency 1 \
                   --scheduler=djcelery.schedulers.DatabaseScheduler
 
 respawn


### PR DESCRIPTION
To try reduce RAM on QA. And because we don't need that many workers.
