### PR TITLE
Pin kombu to a version that works with django-celery 3.0.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ South==0.7.6
 boto==2.8.0.yola1
 django-celery==3.0.10
 django-crispy-forms==1.1.4
+kombu==2.5.12
 python-dateutil==2.1
 raven==2.0.3
 yoconfigurator==0.3.0


### PR DESCRIPTION
Kombu >= 2.5.16 removes kombu.utils.finalize

Fixes: #13
