### PR TITLE
We removed django_markup

### DIFF
--- a/yolapi/settings.py
+++ b/yolapi/settings.py
@@ -130,7 +130,6 @@ INSTALLED_APPS = (
 
     'crispy_forms',
     'django.contrib.staticfiles',
-    'django_markup',
     'djcelery',
     'raven.contrib.django',
     'south',


### PR DESCRIPTION
#24 didn't deploy, because `django_markup` isn't in the virtualenv any more. Those interns...
