### PR TITLE
celerybeat config: Correct bad task import path

### DIFF
--- a/yolapi/yolapi/settings.py
+++ b/yolapi/yolapi/settings.py
@@ -241,7 +241,7 @@ CELERY_QUEUES = (
 if PYPI_SYNC_BUCKET:
     CELERYBEAT_SCHEDULE = {
         'sync': {
-            'task': 'yolapi.sync.tasks.sync',
+            'task': 'sync.tasks.sync',
             'schedule': timedelta(minutes=5),
         },
     }


### PR DESCRIPTION
This path correction was missed in https://github.com/yola/yolapi/pull/28