### PR TITLE
Bump Django to 1.4.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.4.15
+Django==1.4.22
 South==0.7.6
 Pygments==2.1
 boto==2.8.0.yola1


### PR DESCRIPTION
Which is "compatible" with pip 8. By raising an exception, it avoids
building a broken wheel.