### PR TITLE
Specify filename when syncing from S3

### DIFF
--- a/yolapi/sync/tasks.py
+++ b/yolapi/sync/tasks.py
@@ -130,12 +130,13 @@ def pull(filename):
         package, _ = Package.objects.get_or_create(name=package)
         release, created = package.releases.get_or_create(version=version)
 
-    distribution = release.distributions.create(filetype=filetype,
-                                                pyversion=pyversion,
-                                                md5_digest=md5_digest,
-                                                content=File(key),
-                                                created=uploaded,
-                                                sync_imported=True)
+    distribution = release.distributions.create(
+        filetype=filetype,
+        pyversion=pyversion,
+        md5_digest=md5_digest,
+        content=File(key, name=filename),
+        created=uploaded,
+        sync_imported=True)
     distribution.save()
 
     key = bucket.get_key(u'releases/%s/%s' %


### PR DESCRIPTION
Paths were getting double-prefixed with dists/ since the Django & Boto upgrade.
Not entirely sure why this is needed, but it certainly solves the problem.

Fixes: #45