### PR TITLE
We can't just run the celery binary directly

### DIFF
--- a/deploy/templates/systemd/yolapi-beat.service.template
+++ b/deploy/templates/systemd/yolapi-beat.service.template
@@ -6,7 +6,8 @@ After=network.target
 User=www-data
 Group=www-data
 Environment=PYTHONPATH={{conf.deploy.root}}/yolapi/live/yolapi
-ExecStart={{conf.deploy.root}}/yolapi/live/virtualenv/bin/celery beat \
+ExecStart={{conf.deploy.root}}/yolapi/live/virtualenv/bin/python \
+    -m celery beat \
     -A yolapi.celery_setup.app \
         --schedule {{aconf.path.celerybeat_file}} \
         --quiet \

--- a/deploy/templates/systemd/yolapi-worker.service.template
+++ b/deploy/templates/systemd/yolapi-worker.service.template
@@ -6,7 +6,8 @@ After=network.target
 User=www-data
 Group=www-data
 Environment=PYTHONPATH={{conf.deploy.root}}/yolapi/live/yolapi
-ExecStart={{conf.deploy.root}}/yolapi/live/virtualenv/bin/celery \
+ExecStart={{conf.deploy.root}}/yolapi/live/virtualenv/bin/python \
+    -m celery worker \
     -A yolapi.celery_setup.app \
         --quiet \
         --time-limit=1800 \

--- a/deploy/templates/upstart/yolapi-beat.conf.template
+++ b/deploy/templates/upstart/yolapi-beat.conf.template
@@ -7,7 +7,8 @@ env PYTHONPATH={{conf.deploy.root}}/yolapi/live/yolapi
 
 # http://superuser.com/a/234541
 exec su -s /bin/sh -c 'exec "$0" "$@"' www-data -- \
-    {{conf.deploy.root}}/yolapi/live/virtualenv/bin/celery beat \
+    {{conf.deploy.root}}/yolapi/live/virtualenv/bin/python \
+        -m celery beat \
         -A yolapi.celery_setup.app \
             --schedule {{aconf.path.celerybeat_file}} \
             --quiet \

--- a/deploy/templates/upstart/yolapi-worker.conf.template
+++ b/deploy/templates/upstart/yolapi-worker.conf.template
@@ -7,7 +7,8 @@ env PYTHONPATH={{conf.deploy.root}}/yolapi/live/yolapi
 
 # http://superuser.com/a/234541
 exec su -s /bin/sh -c 'exec "$0" "$@"' www-data -- \
-    {{conf.deploy.root}}/yolapi/live/virtualenv/bin/celery worker \
+    {{conf.deploy.root}}/yolapi/live/virtualenv/bin/python \
+        -m celery worker \
         -A yolapi.celery_setup.app \
             --quiet \
             --time-limit=1800 \


### PR DESCRIPTION
We need to use the virtualenv's Python for celery to run within the virtualenv.

At least, we can't on SystemD. For some reason the upstart scripts are happier. But let's keep them in sync.