### PR TITLE
upgrade celery to version compatible with kombu 4.2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==1.11.5
 Pygments==2.2.0
 boto==2.48.0
-celery==4.1.0
+celery==4.1.1
 django-crispy-forms==1.6.1
 django-nose==1.4.5
 docutils==0.14


### PR DESCRIPTION
kombu 4.2.x has been added to yolapi so celery will use that when building virtualenvs.

celery 4.1.0 had a bug when used with kombu 4.2 that was fixed in celery 4.1.1.

See celery/kombu#870 for more info