### PR TITLE
Support Markdown Descriptions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.5
+Django==1.11.17
 Pygments==2.2.0
 boto==2.48.0
 celery==4.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ django-nose==1.4.5
 docutils==0.14
 packaging==16.8
 python-dateutil==2.6.1
+py-gfm==0.1.4
 raven==6.1.0
 redis==2.10.6
 spec==1.4.1

--- a/yolapi/importer/tasks.py
+++ b/yolapi/importer/tasks.py
@@ -52,7 +52,7 @@ def import_requirement(requirement, recurse=True):
                                        develop_ok=False)
         if dist is not None:
             _import_source(dist.location, tmpdir, recurse)
-    except Exception, e:
+    except Exception as e:
         log.exception(e)
     finally:
         shutil.rmtree(tmpdir)

--- a/yolapi/importer/views.py
+++ b/yolapi/importer/views.py
@@ -21,7 +21,7 @@ class RequiresForm(forms.Form):
 
         try:
             list(pkg_resources.parse_requirements(requirements))
-        except ValueError, e:
+        except ValueError as e:
             raise forms.ValidationError(u' '.join(e))
 
         return requirements

--- a/yolapi/pypi/metadata.py
+++ b/yolapi/pypi/metadata.py
@@ -1,3 +1,10 @@
+import re
+
+from django.utils.safestring import mark_safe
+
+from docutils.core import publish_parts
+
+
 def metadata_fields(metadata_version):
     """Return meta-data about the meta-data :)"""
 
@@ -118,3 +125,13 @@ def display_sort(metadata):
         metadata = metadata.items()
 
     return sorted(metadata, key=lambda row: (indices.get(row[0], 100), row))
+
+
+def render_description(text):
+    """Render Description field to HTML"""
+    if re.match(r'^.+(\n {8}.*)+\n?$', text):
+        text = re.sub(r'^ {8}', '', text, flags=re.MULTILINE)
+    html = publish_parts(
+        text, writer_name='html',
+        settings_overrides={'syntax_highlight': 'short'})['html_body']
+    return mark_safe(html)

--- a/yolapi/pypi/metadata.py
+++ b/yolapi/pypi/metadata.py
@@ -3,6 +3,8 @@ import re
 from django.utils.safestring import mark_safe
 
 from docutils.core import publish_parts
+from mdx_gfm import GithubFlavoredMarkdownExtension
+import markdown
 
 
 def metadata_fields(metadata_version):
@@ -127,11 +129,17 @@ def display_sort(metadata):
     return sorted(metadata, key=lambda row: (indices.get(row[0], 100), row))
 
 
-def render_description(text):
+def render_description(text, content_type):
     """Render Description field to HTML"""
     if re.match(r'^.+(\n {8}.*)+\n?$', text):
         text = re.sub(r'^ {8}', '', text, flags=re.MULTILINE)
-    html = publish_parts(
-        text, writer_name='html',
-        settings_overrides={'syntax_highlight': 'short'})['html_body']
+
+    if content_type == 'text/x-rst':
+        html = publish_parts(
+            text, writer_name='html',
+            settings_overrides={'syntax_highlight': 'short'})['html_body']
+    elif content_type == 'text/markdown':
+        html = markdown.markdown(
+            text, extensions=[GithubFlavoredMarkdownExtension()])
+
     return mark_safe(html)

--- a/yolapi/pypi/models.py
+++ b/yolapi/pypi/models.py
@@ -49,7 +49,7 @@ class PyPIStorage(FileSystemStorage):
         if archive_replaced:
             try:
                 os.mkdir(self.path(archive_replaced))
-            except OSError, e:
+            except OSError as e:
                 if e.errno != errno.EEXIST:
                     raise
 

--- a/yolapi/pypi/upload.py
+++ b/yolapi/pypi/upload.py
@@ -84,7 +84,10 @@ def process(request):
                              request.upload_handlers, request.encoding)
     post, files = parser.parse()
 
-    if post.get('protcol_version', None) != '1':
+    # Historically, the protocol field was mis-named, but twine corrected this
+    protocol_version = post.get(
+        'protocol_version', post.get('protcol_version', None))
+    if protocol_version != '1':
         raise InvalidUpload("Missing/Invalid protcol_version")
 
     if post[':action'] != 'file_upload':

--- a/yolapi/pypi/upload.py
+++ b/yolapi/pypi/upload.py
@@ -141,7 +141,7 @@ def parse_metadata(post_data):
 
     try:
         fields = pypi.metadata.metadata_fields(metadata_version)
-    except ValueError, e:
+    except ValueError as e:
         raise InvalidUpload(e)
 
     metadata = {}

--- a/yolapi/pypi/views.py
+++ b/yolapi/pypi/views.py
@@ -38,9 +38,9 @@ def upload(request):
                                          content_type='text/plain')
     try:
         pypi.upload.process(request)
-    except pypi.upload.InvalidUpload, e:
+    except pypi.upload.InvalidUpload as e:
         return HttpResponseBadRequest(unicode(e), content_type='text/plain')
-    except pypi.upload.ReplacementDenied, e:
+    except pypi.upload.ReplacementDenied as e:
         return HttpResponseForbidden(unicode(e), content_type='text/plain')
     return HttpResponse('Accepted, thank you', content_type='text/plain')
 

--- a/yolapi/pypi/views.py
+++ b/yolapi/pypi/views.py
@@ -74,7 +74,10 @@ def release(request, package, version):
             metadata[key] = '\n'.join(values)
 
     if 'Description' in metadata:
-        metadata['Description'] = render_description(metadata['Description'])
+        content_type = metadata.get('Description-Content-Type', 'text/x-rst')
+        content_type = content_type.split(';', 1)[0]
+        metadata['Description'] = render_description(
+            metadata['Description'], content_type)
 
     return render(request, 'pypi/release.html', {
         'title': unicode(release),

--- a/yolapi/pypi/views.py
+++ b/yolapi/pypi/views.py
@@ -69,24 +69,25 @@ def release(request, package, version):
     except Release.DoesNotExist:
         raise Http404
 
-    metadata = pypi.metadata.display_sort(release.metadata_dict)
+    metadata = release.metadata_dict
 
     # Flatten lists
-    for i, (key, values) in enumerate(metadata):
+    for key, values in metadata.items():
         if isinstance(values, list):
-            metadata[i] = (key, '\n'.join(values))
+            metadata[key] = '\n'.join(values)
+
         if key == 'Description':
             if re.match(r'^.+(\n {8}.*)+\n?$', values):
                 values = re.sub(r'^ {8}', '', values, flags=re.MULTILINE)
             values = publish_parts(
                 values, writer_name='html',
                 settings_overrides={'syntax_highlight': 'short'})['html_body']
-            metadata[i] = (key, mark_safe(values))
+            metadata[key] = mark_safe(values)
 
     return render(request, 'pypi/release.html', {
         'title': unicode(release),
         'release': release,
-        'metadata': metadata,
+        'metadata': pypi.metadata.display_sort(metadata),
     })
 
 


### PR DESCRIPTION
As introduced in Metadata 2.1.

The `Content-Type-Description` field will only be set for sources that were uploaded by `twine` or imported from PyPI, when it's set there.

So, while we're here, let's fix #51, and support twine uploads.