### PR TITLE
Upgrade libs. raven->sentry_sdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,19 @@
-Django==1.11.17
-Markdown==2.6.11
-Pygments==2.2.0
-boto==2.48.0
-bleach==2.1.4
-bleach-whitelist==0.0.9
-celery==4.1.1
-django-crispy-forms==1.6.1
-django-nose==1.4.5
-docutils==0.14
-packaging==16.8
-py-gfm==0.1.4
-python-dateutil==2.6.1
-raven==6.1.0
-redis==2.10.6
-spec==1.4.1
-yoconfigurator==0.5.2
+Django == 1.11.24
+Markdown == 2.6.11
+Pygments == 2.4.2
+boto == 2.49.0
+bleach == 3.1.0
+bleach-whitelist == 0.0.10
+celery == 4.3.0
+django-crispy-forms == 1.7.2
+docutils == 0.15.2
+packaging == 19.1
+py-gfm == 0.1.4
+python-dateutil == 2.8.0
+redis == 3.3.8
+sentry-sdk == 0.11.2
+yoconfigurator == 0.5.2
+
+# Development dependencies:
+django-nose == 1.4.6
+spec == 1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ docutils == 0.15.2
 packaging == 19.1
 py-gfm == 0.1.4
 python-dateutil == 2.8.0
-redis == 3.3.8
+redis[hiredis] == 3.3.8
 sentry-sdk == 0.11.2
 yoconfigurator == 0.5.2
 

--- a/yolapi/yolapi/settings.py
+++ b/yolapi/yolapi/settings.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
-from sentry_sdk.integrations.redis import RedisIntegration
 from yoconfigurator.base import read_config
 
 
@@ -196,5 +195,5 @@ NOSE_ARGS = ['--with-specplugin', '--where=%s' % app_dir]
 
 sentry_sdk.init(
     dsn=aconf.sentry_dsn,
-    integrations=[CeleryIntegration(), DjangoIntegration(), RedisIntegration()]
+    integrations=[CeleryIntegration(), DjangoIntegration()]
 )

--- a/yolapi/yolapi/wsgi.py
+++ b/yolapi/yolapi/wsgi.py
@@ -21,6 +21,5 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'yolapi.settings')
 
 
 from django.core.wsgi import get_wsgi_application  # NOQA
-from raven.contrib.django.middleware.wsgi import Sentry  # NOQA
 
-application = Sentry(get_wsgi_application())
+application = get_wsgi_application()


### PR DESCRIPTION
Just regular upgrading libs.

`hiredis` was added as extra to `redis`.

Wasn't done:
* `Markdown` wasn't upgraded cause `py-gfm` can't work with new versions.
* `boto` -> `boto3` cause needs test new code.