### PR TITLE
Use "original" pypi description renderer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,11 @@
 Django == 4.2.16
-Markdown == 2.6.11
-Pygments == 2.5.2
 boto3 == 1.35.11
-bleach == 3.3.1
-bleach-whitelist == 0.0.11
 celery == 5.4.0
 crispy-forms-bootstrap2 == 2024.1
 django-crispy-forms == 2.3
-docutils == 0.17.1
 packaging == 20.9
-py-gfm == 0.1.4
 python-dateutil == 2.9.0.post0
+readme-renderer[md] == 43.0
 redis[hiredis] == 5.0.8
 sentry-sdk == 2.13.0
 yoconfigurator == 0.5.2

--- a/yolapi/pypi/metadata.py
+++ b/yolapi/pypi/metadata.py
@@ -1,11 +1,8 @@
-from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
-import bleach
-from bleach_whitelist import all_styles, print_attrs, print_tags
-from docutils.core import publish_parts
-from markdown import markdown
-from mdx_gfm import GithubFlavoredMarkdownExtension
+from readme_renderer.markdown import render as render_markdown
+from readme_renderer.rst import render as render_rst
+from readme_renderer.txt import render as render_txt
 
 
 def metadata_fields(metadata_version):
@@ -138,15 +135,9 @@ def display_sort(metadata):
 def render_description(text, content_type):
     """Render Description field to HTML"""
     if content_type == 'text/x-rst':
-        html = publish_parts(
-            text, writer_name='html',
-            settings_overrides={'syntax_highlight': 'short'})['html_body']
+        html = render_rst(text)
     elif content_type == 'text/markdown':
-        html = markdown(text, extensions=[GithubFlavoredMarkdownExtension()])
+        html = render_markdown(text)
     else:
-        html = format_html('<pre>{}</pre>', text)
-
-    html = bleach.clean(
-        html, print_tags + ['a', 'cite', 'pre'], print_attrs, all_styles)
-
+        html = render_txt(text)
     return mark_safe(html)


### PR DESCRIPTION
`readme-renderer` uses in pypi.

Readme Renderer is a library that will safely render arbitrary README files into HTML. It is designed to be used in [Warehouse](https://github.com/pypa/warehouse) to render the long_description for packages. It can handle Markdown, reStructuredText (.rst), and plain text.
