### PR TITLE
Use descendant releases ordering on package page

### DIFF
--- a/yolapi/pypi/models.py
+++ b/yolapi/pypi/models.py
@@ -66,13 +66,16 @@ class Package(models.Model):
                                          primary_key=True, editable=False)
 
     @property
-    def sorted_releases(self):
-        return sorted(self.releases.iterator(),
-                      key=lambda r: parse_version(r.version))
+    def sorted_releases_desc(self):
+        return sorted(
+            self.releases.iterator(),
+            key=lambda r: parse_version(r.version),
+            reverse=True
+        )
 
     @property
     def latest(self):
-        return self.sorted_releases[-1]
+        return self.sorted_releases_desc[0]
 
     def gc(self):
         if not self.releases.exists():

--- a/yolapi/pypi/templates/pypi/package.html
+++ b/yolapi/pypi/templates/pypi/package.html
@@ -13,7 +13,7 @@
 			<th>Uploaded</th>
 		</tr>
 	</thead>
-{% for release in package.sorted_releases %}
+{% for release in package.sorted_releases_desc %}
 	<tr>
 		<td>
 			<a href="{% url 'pypi:release' package=package.name version=release.version %}">


### PR DESCRIPTION
old:
<img width="700" alt="Screenshot 2024-09-04 at 13 25 49" src="https://github.com/user-attachments/assets/abe31c80-5589-4789-870e-7c3b64ade348">


new:
<img width="712" alt="Screenshot 2024-09-04 at 13 24 47" src="https://github.com/user-attachments/assets/ed37f439-2fab-45f4-b41f-7d95c98ec283">
